### PR TITLE
Remove normalize css

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem "omniauth-cas"
 gem "omniauth-rails_csrf_protection"
 gem "pg"
 gem 'simple_form'
-gem 'normalize-rails'
 gem 'susy'
 gem 'breakpoint'
 gem 'bourbon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
-    normalize-rails (3.0.3)
     omniauth (2.1.2)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -418,7 +417,6 @@ DEPENDENCIES
   jquery-tablesorter
   modernizr-rails
   nokogiri
-  normalize-rails
   omniauth
   omniauth-cas
   omniauth-rails_csrf_protection

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,7 +10,6 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- *= require normalize-rails
  *= require jquery-tablesorter/theme.black-ice
  *= require_self
  *= require_tree .


### PR DESCRIPTION
These are some CSS rules that make the appearance of certain UI elements the same across browsers.  It looks fine in Chrome and Firefox without it to me, and the version we are using is over 9 years old, so I thought we could simplify and remove it.