### PR TITLE
Add Content Security Policy in report-only mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem 'susy'
 gem 'breakpoint'
 gem 'bourbon'
 gem 'jquery-tablesorter'
-gem 'modernizr-rails'
 gem "nokogiri"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,6 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.1)
-    modernizr-rails (2.7.1)
     net-http (0.4.1)
       uri
     net-imap (0.4.16)
@@ -401,7 +400,6 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   jquery-tablesorter
-  modernizr-rails
   nokogiri
   omniauth
   omniauth-cas

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,10 +3,9 @@
 <head>
   <title>Repec</title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= stylesheet_link_tag    'https://unpkg.com/lux-design-system@5/dist/style.css' %>
-  <%= javascript_include_tag :modernizr %>
-  <%= javascript_include_tag 'https://unpkg.com/vue@3/dist/vue.global.prod.js' %>
-  <%= javascript_include_tag 'https://unpkg.com/lux-design-system@5/dist/lux-styleguidist.iife.js' %>
+  <%= stylesheet_link_tag    'https://unpkg.com/lux-design-system@5.6.3/dist/style.css' %>
+  <%= javascript_include_tag 'https://unpkg.com/vue@3.5.6/dist/vue.global.prod.js', nonce: true %>
+  <%= javascript_include_tag 'https://unpkg.com/lux-design-system@5.6.3/dist/lux-styleguidist.iife.js', nonce: true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
 </head>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,22 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self
+  policy.img_src     :self, :https, :data
+  policy.media_src   :self, :https, :data
+  policy.script_src  :self, :unsafe_eval
+  policy.script_src_attr :unsafe_inline
+  policy.script_src_elem :self
+  policy.style_src_elem :self, 'https://unpkg.com', :unsafe_inline
+  policy.frame_ancestors :none
+end
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_directives = %w(script-src-elem)
 
-# If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
-
-# Report CSP violations to a specified URI
-# For further information see the following documentation:
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-# Rails.application.config.content_security_policy_report_only = true
+# Currently, don't enforce the CSP.
+# We should add Honeybadger to this application and report
+# CSP violations there.  Once we have no reports, we could
+# then turn on the CSP for real.
+Rails.application.config.content_security_policy_report_only = true


### PR DESCRIPTION
* Remove modernizr, since it caused policy violations and we don't need it.
* Add a CSP in report-only mode.  It won't block anything, but will log violations to the console.  Once we add Honeybadger to this application, we can configure it to receive warnings about CSP violations.