### PR TITLE
Remove terser, which relies on execjs/node

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org'
 gem 'rails', '~> 7.1'
 # Use SCSS for stylesheets
 gem 'sass-rails'
-gem 'terser'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,6 @@ GEM
     dumb_delegator (1.0.0)
     ed25519 (1.3.0)
     erubi (1.13.0)
-    execjs (2.9.1)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -361,8 +360,6 @@ GEM
     stringio (3.1.1)
     susy (2.2.14)
       sass (>= 3.3.0, < 3.5)
-    terser (1.1.20)
-      execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     thread_safe (0.3.6)
     tilt (2.3.0)
@@ -441,7 +438,6 @@ DEPENDENCIES
   selenium-webdriver
   simple_form
   susy
-  terser
   web-console
   webmock
   webrick

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,10 +25,6 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :terser
-  # config.assets.css_compressor = :sass
-
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -25,10 +25,6 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :terser
-  # config.assets.css_compressor = :sass
-
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 


### PR DESCRIPTION
Helps with #165, since this is our only dependency on node